### PR TITLE
Case reproducing bundler-5046

### DIFF
--- a/cases/install/re-install.rb
+++ b/cases/install/re-install.rb
@@ -1,0 +1,21 @@
+BundlerCase.define version: '1.13.2' do
+  step do
+    given_gems { fake_system_gem 'fakogiri', '1.6.8.1' }
+    given_gemfile do
+      <<-G
+source "fake"
+gem 'fakogiri'
+      G
+    end
+
+    execute_bundler { 'bundle install' }
+  end
+
+  step do
+    execute_bundler { 'gem uninstall fakogiri' }
+  end
+
+  step do
+    execute_bundler { 'bundle install' }
+  end
+end


### PR DESCRIPTION
https://github.com/bundler/bundler/issues/5046

Output from case:

```
[chrismo@momac bundler-cases (master)]$ ./run_cases.rb 5046
================================================================================
                                  Bundler-5046
================================================================================
  Successfully built RubyGem
  Name: fakogiri
  Version: 1.6.8.1
  File: fakogiri-1.6.8.1.gem
Generating Marshal quick index gemspecs for 0 gems

Complete
Generated Marshal quick index gemspecs: 0.000s
Generating specs index
Generated specs index: 0.000s
Generating latest specs index
Generated latest specs index: 0.000s
Generating prerelease specs index
Generated prerelease specs index: 0.000s
Compressing indices
Compressed indices: 0.003s
=> bundle _1.11.2_ lock
Fetching gem metadata from https://rubygems.org/..
Fetching version metadata from https://rubygems.org/.
Resolving dependencies...
Writing lockfile to /Users/chrismo/dev/bundler-cases/out/Gemfile.lock
=> bundle _1.11.2_ install
Resolving dependencies...
Using fakogiri 1.6.8.1
Using bundler 1.11.2
Bundle complete! 1 Gemfile dependency, 2 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.

=> gem uninstall fakogiri
Successfully uninstalled fakogiri-1.6.8.1

=> bundle _1.11.2_ install
Fetching gem metadata from https://rubygems.org/..
Fetching version metadata from https://rubygems.org/.
Could not find fakogiri-1.6.8.1 in any of the sources

=> bundle _1.13.2_ install
Fetching gem metadata from https://rubygems.org/.
Fetching version metadata from https://rubygems.org/
Your bundle is locked to fakogiri (1.6.8.1), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of fakogiri (1.6.8.1) has removed it. You'll need to update your bundle to a different version of fakogiri (1.6.8.1) that hasn't been removed in order to install.

```
